### PR TITLE
Windows line endings fixes + filterdiff restored

### DIFF
--- a/plugin/patchreview.vim
+++ b/plugin/patchreview.vim
@@ -290,7 +290,7 @@ function! <SID>ExtractDiffsPureVim(...)                                   "{{{
   endif
   let collect = []
   let line_num = 0
-  let lines = readfile(patchfile)
+  let lines = readfile(patchfile, "b")
   let linescount = len(lines)
   State 'START'
   while line_num < linescount


### PR DESCRIPTION
I guess you can drop the filterdiff patch if you don't need it. The other 2 for windows line endings are as we discussed.

thanks,

Richard
