### PR TITLE
Add patchreview_reverse_windows option.

### DIFF
--- a/autoload/patchreview.vim
+++ b/autoload/patchreview.vim
@@ -850,6 +850,12 @@ function! s:generic_review(argslist)                                   "{{{
     return
   endif
 
+  if (! exists('g:patchreview_reverse_windows') || g:patchreview_reverse_windows == 0)
+    let l:leftright = 'topleft'
+  else
+    let l:leftright = 'botright'
+  endif
+
   " ----------------------------- patch ------------------------------------
   if s:reviewmode =~ 'patch'
     let l:argc = len(a:argslist)
@@ -1056,7 +1062,7 @@ function! s:generic_review(argslist)                                   "{{{
       "else
         silent! exe 'tabedit ' . fnameescape(l:stripped_rel_path)
         if filereadable(l:tmp_patched) && l:pout =~ 'Only garbage was found in the patch input'
-          topleft new
+          exe l:leftright new
           exe 'r ' . fnameescape(l:tmp_patch)
           normal! gg
           0 delete _
@@ -1073,7 +1079,7 @@ function! s:generic_review(argslist)                                   "{{{
           " modelines in loaded files mess with diff comparison
           let s:keep_modeline=&modeline
           let &modeline=0
-          silent! exe 'vert diffsplit ' . fnameescape(l:tmp_patched)
+          silent! exe l:leftright 'vert diffsplit ' . fnameescape(l:tmp_patched)
           setlocal noswapfile
           setlocal syntax=none
           setlocal bufhidden=delete
@@ -1103,7 +1109,7 @@ function! s:generic_review(argslist)                                   "{{{
         " modelines in loaded files mess with diff comparison
         let s:keep_modeline=&modeline
         let &modeline=0
-        silent! exe 'topleft split ' . fnameescape(l:tmp_patch)
+        silent! exe l:leftright 'split ' . fnameescape(l:tmp_patch)
         setlocal noswapfile
         setlocal syntax=none
         setlocal bufhidden=delete
@@ -1122,7 +1128,7 @@ function! s:generic_review(argslist)                                   "{{{
         " modelines in loaded files mess with diff comparison
         let s:keep_modeline=&modeline
         let &modeline=0
-        silent! exe 'topleft split ' . fnameescape(l:tmp_patched_rej)
+        silent! exe l:leftright 'split ' . fnameescape(l:tmp_patched_rej)
         " Try to convert rejects to unified format unless explicitly disabled
         if (! exists('g:patchreview_unified_rejects') || g:patchreview_unified_rejects == 1) &&
               \ getline(1) =~ '\m\*\{15}'

--- a/doc/patchreview.txt
+++ b/doc/patchreview.txt
@@ -105,6 +105,7 @@ The following variables are available:
 |patchreview_patch_needs_crlf|
 |patchreview_wiggle|
 |patchreview_unified_rejects|
+|patchreview_reverse_windows|
 
 
                                                         *g:patchreview_patch*
@@ -164,6 +165,19 @@ The following variables are available:
 
     Example:
         let g:patchreview_unified_rejects = 1
+<
+
+                                              *g:patchreview_reverse_windows*
+                                                *patchreview_reverse_windows*
+  g:patchreview_reverse_windows = {1}
+      By default, the current version of each file will be displayed on the
+      right, and the results of the patch or diff review will be on the left.
+      This is the same model used by the built-in :vert diffpatch command.
+
+      To reverse these windows, set this option to 1.
+
+    Example:
+        let g:patchreview_reverse_windows = 1
 <
 Hooks                                                       *patchreview-hooks*
 


### PR DESCRIPTION
This option, if set, reverses the order of the patch/diff
vertical split windows: the current file will be on the left
and the modified file will be on the right.
